### PR TITLE
Improve the API to get clean UTF-8 data from a response

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,9 @@
+error_chain! {
+    errors {
+        // The response is not nul-terminated, or it is not valid ASCII/UTF-8
+        MalformedResponse {
+            description ("malformed response")
+            display ("response is not a valid nul-terminated UTF-8 string")
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,6 @@ mod tests {
         assert_eq!(response_code(0), ResponseCode::UnknownError);
         assert_eq!(response_code(16), ResponseCode::UnknownError);
         assert_eq!(response_code(156), ResponseCode::UnknownError);
-        assert_eq!(response_code(256), ResponseCode::UnknownError);
     }
     #[test]
     fn parsing_nonzeros_response() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,7 @@
 extern crate error_chain;
 extern crate i2cdev;
 
-/// Use error-chain for error-handling.
-pub mod errors {
-    error_chain!{}
-}
+pub mod errors;
 
 use errors::*;
 use i2cdev::core::I2CDevice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,15 +91,24 @@ pub fn read_raw_buffer(dev: &mut LinuxI2CDevice, max_data: usize) -> Result<Vec<
     Ok(data_buffer)
 }
 
+/// Turns off the high bit in each of the bytes of `v`.  Raspberry Pi
+/// for some reason outputs i2c buffers with some of the high bits
+/// turned on.
+pub fn turn_off_high_bits(v: &mut [u8]) {
+    for b in v.iter_mut () {
+        *b = *b & 0x7f;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
-    fn determine_if_response_is_ascii() {
+    fn turns_off_high_bits() {
         let data: [u8; 11] = [63, 73, 44, 112, 72, 44, 49, 46, 57, 56, 0];
-        let flipped_data: [u8; 11] = [63, 73, 172, 112, 200, 172, 49, 46, 57, 56, 0];
-        assert_eq!(data.is_ascii(), true);
-        assert_eq!(flipped_data.is_ascii(), false);
+        let mut flipped_data: [u8; 11] = [63, 73, 172, 112, 200, 172, 49, 46, 57, 56, 0];
+        turn_off_high_bits(&mut flipped_data);
+        assert_eq!(data, flipped_data);
     }
     #[test]
     fn process_no_data_response_code() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,11 @@ pub fn turn_off_high_bits(v: &mut [u8]) {
 ///
 /// This function ensures that the response is a nul-terminated string
 /// and that it is valid UTF-8 (a superset of ASCII).
+///
+/// After reading your buffer from the i2c device, check the first
+/// byte for the response code.  Then, pass a slice with the rest of
+/// the buffer (without that first byte) to this function to get an
+/// UTF-8 string.
 pub fn string_from_response_data(response: &[u8]) -> Result<String> {
     let mut buf = response.to_owned ();
     turn_off_high_bits (&mut buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub fn read_raw_buffer(dev: &mut LinuxI2CDevice, max_data: usize) -> Result<Vec<
 /// Turns off the high bit in each of the bytes of `v`.  Raspberry Pi
 /// for some reason outputs i2c buffers with some of the high bits
 /// turned on.
-pub fn turn_off_high_bits(v: &mut [u8]) {
+fn turn_off_high_bits(v: &mut [u8]) {
     for b in v.iter_mut () {
         *b = *b & 0x7f;
     }


### PR DESCRIPTION
Instead of returning vectors with zero bytes for malformed responses, we actually return a Result<String> now.  There is a new string_from_response_data() function that is used by callers to clean up the raw data from the i2c device.